### PR TITLE
fix: add link for the CI badge to point to status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- Autonomous agent capability enabled 2026-02-15 -->
 <!-- Autonomous agent capability enabled 2026-02-15 -->
-![CI](https://img.shields.io/github/actions/workflow/status/jordanhubbard/loom/ci.yml?branch=main)
+[![CI](https://github.com/jordanhubbard/loom/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jordanhubbard/loom/actions/workflows/ci.yml?query=branch%3Amain)
 ![Coverage](https://img.shields.io/codecov/c/github/jordanhubbard/loom/main)
 ![Go Version](https://img.shields.io/github/go-mod/go-version/jordanhubbard/loom)
 


### PR DESCRIPTION
Currently, clicking on the CI badge just opens the badge itself in a new tab.

After this change, clicking on the CI badge takes us to the list of the workflow runs in the Actions tab so we can see the history or jump quickly to the errors from the most recent run, making it much more useful.

Since this change doesn't impact any cide, we can [skip ci].