### PR TITLE
feat: workflow state persistence + startup orphan recovery

### DIFF
--- a/internal/database/workflows.go
+++ b/internal/database/workflows.go
@@ -489,6 +489,53 @@ func (d *Database) DeleteWorkflowExecutionByBeadID(beadID string) error {
 	return err
 }
 
+// ListActiveWorkflowExecutions returns all executions with status 'active'.
+// Used on startup to identify orphaned executions that were interrupted by a restart.
+func (d *Database) ListActiveWorkflowExecutions() ([]*workflow.WorkflowExecution, error) {
+	rows, err := d.db.Query(rebind(`
+		SELECT id, workflow_id, bead_id, project_id,
+		       current_node_key, status, cycle_count, node_attempt_count,
+		       started_at, completed_at, escalated_at, last_node_at
+		FROM workflow_executions
+		WHERE status = ?
+		ORDER BY last_node_at ASC
+	`), string(workflow.ExecutionStatusActive))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []*workflow.WorkflowExecution
+	for rows.Next() {
+		exec := &workflow.WorkflowExecution{}
+		if err := rows.Scan(
+			&exec.ID, &exec.WorkflowID, &exec.BeadID, &exec.ProjectID,
+			&exec.CurrentNodeKey, &exec.Status, &exec.CycleCount, &exec.NodeAttemptCount,
+			&exec.StartedAt, &exec.CompletedAt, &exec.EscalatedAt, &exec.LastNodeAt,
+		); err != nil {
+			return nil, err
+		}
+		results = append(results, exec)
+	}
+	return results, rows.Err()
+}
+
+// ResetOrphanedWorkflowExecutions finds all active executions and resets them to
+// 'blocked' so the dispatcher can re-pick them up after a server restart.
+// Returns the number of executions reset.
+func (d *Database) ResetOrphanedWorkflowExecutions() (int, error) {
+	result, err := d.db.Exec(rebind(`
+		UPDATE workflow_executions
+		SET status = ?, last_node_at = ?
+		WHERE status = ?
+	`), string(workflow.ExecutionStatusBlocked), time.Now(), string(workflow.ExecutionStatusActive))
+	if err != nil {
+		return 0, err
+	}
+	n, _ := result.RowsAffected()
+	return int(n), nil
+}
+
 // InsertWorkflowHistory adds a history entry for a workflow execution
 func (d *Database) InsertWorkflowHistory(history *workflow.WorkflowExecutionHistory) error {
 	if history == nil {

--- a/internal/loom/loom_lifecycle.go
+++ b/internal/loom/loom_lifecycle.go
@@ -1748,6 +1748,16 @@ func (e loomCEOEscalator) EscalateBeadToCEO(beadID, reason, returnedTo string) e
 // It creates a taskexecutor.Executor and launches worker goroutines per project.
 // Call this instead of StartDispatchLoop to bypass Temporal/NATS/WorkerPool overhead.
 func (a *Loom) StartTaskExecutor(ctx context.Context) {
+	// Recover any workflow executions orphaned by a previous crash or restart.
+	// Must run before workers start so no bead is skipped due to stale 'active' status.
+	if a.workflowEngine != nil {
+		if n, err := a.workflowEngine.RecoverOrphanedExecutions(); err != nil {
+			log.Printf("[Loom] WARNING: workflow orphan recovery failed: %v", err)
+		} else if n > 0 {
+			log.Printf("[Loom] Startup: recovered %d orphaned workflow execution(s)", n)
+		}
+	}
+
 	exec := taskexecutor.New(
 		a.providerRegistry,
 		a.beadsManager,

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,6 +24,9 @@ type Database interface {
 	InsertWorkflowHistory(history *WorkflowExecutionHistory) error
 	ListWorkflowHistory(executionID string) ([]*WorkflowExecutionHistory, error)
 	DeleteWorkflowExecutionByBeadID(beadID string) error
+	// Startup recovery: find and reset orphaned executions left active by a prior crash/restart.
+	ListActiveWorkflowExecutions() ([]*WorkflowExecution, error)
+	ResetOrphanedWorkflowExecutions() (int, error)
 }
 
 // BeadManager interface for bead operations
@@ -52,6 +56,23 @@ func NewEngine(db Database, beads BeadManager) *Engine {
 // GetDatabase returns the underlying database interface
 func (e *Engine) GetDatabase() Database {
 	return e.db
+}
+
+// RecoverOrphanedExecutions resets workflow executions that were left in 'active'
+// state by a previous server crash or restart. Call this once at startup before
+// the dispatcher begins processing beads. Returns the number of executions reset.
+//
+// Orphaned executions have their status set back to 'blocked' so the dispatcher
+// will re-pick them up and resume from the last persisted node.
+func (e *Engine) RecoverOrphanedExecutions() (int, error) {
+	n, err := e.db.ResetOrphanedWorkflowExecutions()
+	if err != nil {
+		return 0, fmt.Errorf("workflow recovery: failed to reset orphaned executions: %w", err)
+	}
+	if n > 0 {
+		log.Printf("[WorkflowEngine] Startup recovery: reset %d orphaned active execution(s) to blocked", n)
+	}
+	return n, nil
 }
 
 // StartWorkflow initiates a workflow for a bead
@@ -577,26 +598,63 @@ func (e *Engine) CheckNodeTimeout(execution *WorkflowExecution) error {
 	return nil
 }
 
-// GetWorkflowForBead determines which workflow to use for a bead
+// GetWorkflowForBead determines which workflow to use for a bead.
+// Detection priority: explicit beadType field → title keyword heuristics → "bug" default.
 func (e *Engine) GetWorkflowForBead(beadType, beadTitle, projectID string) (*Workflow, error) {
-	// Determine workflow type from bead type/title
-	workflowType := "bug" // Default
-
-	// TODO: Add heuristics to detect workflow type from bead
-	// For now, use simple mapping:
-	// - Beads with "UI" or "design" → "ui"
-	// - Beads with "feature" or "enhancement" → "feature"
-	// - Everything else → "bug"
+	workflowType := detectWorkflowType(beadType, beadTitle)
 
 	workflows, err := e.db.ListWorkflows(workflowType, projectID)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(workflows) == 0 {
-		return nil, fmt.Errorf("no workflow found for type %s", workflowType)
+	// Fall back to "bug" workflow if no match for detected type
+	if len(workflows) == 0 && workflowType != "bug" {
+		log.Printf("[WorkflowEngine] No workflow found for type %q (project %s), falling back to 'bug'", workflowType, projectID)
+		workflows, err = e.db.ListWorkflows("bug", projectID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// Return first matching workflow (prioritizes project-specific, then defaults)
+	if len(workflows) == 0 {
+		return nil, fmt.Errorf("no workflow found for type %s (project %s)", workflowType, projectID)
+	}
+
+	// Return first matching workflow (project-specific rows sort before globals in ListWorkflows)
 	return workflows[0], nil
+}
+
+// detectWorkflowType maps a bead's type field and title to a workflow type string.
+// Rules (in order of precedence):
+//  1. Explicit beadType if it's a known type
+//  2. Title keywords: UI/design/frontend → "ui"; feature/enhancement/improvement/add/implement → "feature"
+//  3. Default: "bug"
+func detectWorkflowType(beadType, beadTitle string) string {
+	// Normalize
+	bt := strings.ToLower(strings.TrimSpace(beadType))
+	title := strings.ToLower(beadTitle)
+
+	// Known explicit types win immediately
+	switch bt {
+	case "ui", "feature", "bug":
+		return bt
+	}
+
+	// Title keyword heuristics
+	uiKeywords := []string{"ui", "ux", "design", "frontend", "front-end", "layout", "style", "css", "component", "visual"}
+	for _, kw := range uiKeywords {
+		if strings.Contains(title, kw) {
+			return "ui"
+		}
+	}
+
+	featureKeywords := []string{"feature", "enhancement", "improvement", "implement", "add ", "support ", "integrate", "new "}
+	for _, kw := range featureKeywords {
+		if strings.Contains(title, kw) {
+			return "feature"
+		}
+	}
+
+	return "bug"
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -350,6 +350,28 @@ func (m *mockDatabase) DeleteWorkflowExecutionByBeadID(beadID string) error {
 	return nil
 }
 
+func (m *mockDatabase) ListActiveWorkflowExecutions() ([]*WorkflowExecution, error) {
+	var result []*WorkflowExecution
+	for _, exec := range m.executions {
+		if exec.Status == ExecutionStatusActive {
+			e := *exec
+			result = append(result, &e)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockDatabase) ResetOrphanedWorkflowExecutions() (int, error) {
+	n := 0
+	for _, exec := range m.executions {
+		if exec.Status == ExecutionStatusActive {
+			exec.Status = ExecutionStatusBlocked
+			n++
+		}
+	}
+	return n, nil
+}
+
 type mockBeadManager struct {
 	beads map[string]map[string]interface{}
 }


### PR DESCRIPTION
## What

Three interlocked changes that fix workflow progress being lost on server restart.

### 1. DB layer (`internal/database/workflows.go`)
- `ListActiveWorkflowExecutions()` — query all executions with `status='active'`
- `ResetOrphanedWorkflowExecutions()` — bulk-reset `active→blocked` at startup

### 2. Workflow engine (`internal/workflow/engine.go`)
- Interface updated with the two new DB methods
- `RecoverOrphanedExecutions()` — engine-level recovery with startup logging
- `detectWorkflowType()` — replaces the TODO stub:
  - `UI/design/frontend/css/component` → `ui`
  - `feature/enhancement/implement/add/integrate` → `feature`
  - Default → `bug`, falls back to `bug` if no workflow found for detected type

### 3. Startup wiring (`internal/loom/loom_lifecycle.go`)
- `RecoverOrphanedExecutions()` called at top of `StartTaskExecutor()`, before workers spin up

## Why

On restart, the `inflight` map (in-memory) is empty but `workflow_executions` rows with `status='active'` exist in the DB. Without recovery, those beads are stuck — the dispatcher won't re-dispatch them because `GetWorkflowExecutionByBeadID` returns an active execution that no agent is actually holding.

The fix resets them to `blocked` so they get picked up cleanly on the next dispatch cycle.

## Tests
- `go test ./internal/workflow/... ./internal/database/...` ✅
- `go build ./...` ✅