### PR TITLE
fix: Align LLMMaker with current types schema to unblock build

### DIFF
--- a/internal/decision/llm_maker.go
+++ b/internal/decision/llm_maker.go
@@ -3,7 +3,7 @@ package decision
 // LLMMaker is an AI-backed decision maker that calls the RCC brain API
 // for reasoning about which agent should handle a task.
 //
-// It satisfies the Maker interface and is used in place of (or chained
+// It satisfies the types.DecisionMaker interface and is used in place of (or chained
 // after) SimpleMaker when LOOM_RCC_BRAIN_URL is set in the environment.
 // When the brain API is unavailable or times out, it falls back to
 // SimpleMaker so loom is never blocked on RCC availability.
@@ -30,7 +30,7 @@ import (
 	"github.com/jordanhubbard/loom/pkg/types"
 )
 
-// LLMMaker implements the Maker interface using the RCC brain API.
+// LLMMaker implements the types.DecisionMaker interface using the RCC brain API.
 type LLMMaker struct {
 	brainURL   string
 	brainToken string
@@ -39,8 +39,8 @@ type LLMMaker struct {
 	httpClient *http.Client
 }
 
-// Ensure LLMMaker satisfies the Maker interface at compile time.
-var _ Maker = (*LLMMaker)(nil)
+// Ensure LLMMaker satisfies the types.DecisionMaker interface at compile time.
+var _ types.DecisionMaker = (*LLMMaker)(nil)
 
 // NewLLMMaker creates a new LLM-backed decision maker.
 // brainURL is the RCC brain endpoint (e.g. "http://rocky:8789").
@@ -68,19 +68,25 @@ func (m *LLMMaker) IsAvailable() bool {
 	return m.brainURL != ""
 }
 
-// Decide selects the most appropriate agent for a task using LLM reasoning.
+// EvaluatePriority delegates priority evaluation to the SimpleMaker fallback.
+// LLM-based priority scoring is not currently implemented.
+func (m *LLMMaker) EvaluatePriority(task *types.Task) int {
+	return m.fallback.EvaluatePriority(task)
+}
+
+// DecideAgent selects the most appropriate agent for a task using LLM reasoning.
 // Falls back to SimpleMaker if the brain API is unreachable or returns an
 // unusable response.
-func (m *LLMMaker) Decide(ctx context.Context, task *types.Task, agents []*types.Agent) (*types.Agent, error) {
+func (m *LLMMaker) DecideAgent(ctx context.Context, task *types.Task, agents []*types.Agent) (*types.Agent, error) {
 	if !m.IsAvailable() || len(agents) == 0 {
-		return m.fallback.Decide(ctx, task, agents)
+		return m.fallback.DecideAgent(ctx, task, agents)
 	}
 
 	prompt := m.buildPrompt(task, agents)
 	result, err := m.callBrain(ctx, prompt)
 	if err != nil {
 		// Brain unreachable — fall back silently
-		return m.fallback.Decide(ctx, task, agents)
+		return m.fallback.DecideAgent(ctx, task, agents)
 	}
 
 	// Parse LLM response: look for an agent name in the output
@@ -89,7 +95,7 @@ func (m *LLMMaker) Decide(ctx context.Context, task *types.Task, agents []*types
 		return chosen, nil
 	}
 	// LLM gave an unusable response — fall back
-	return m.fallback.Decide(ctx, task, agents)
+	return m.fallback.DecideAgent(ctx, task, agents)
 }
 
 // buildPrompt constructs the LLM prompt for agent selection.
@@ -100,17 +106,14 @@ func (m *LLMMaker) buildPrompt(task *types.Task, agents []*types.Agent) string {
 	if task.Description != "" {
 		sb.WriteString(fmt.Sprintf("  Description: %s\n", task.Description))
 	}
-	if len(task.Labels) > 0 {
-		sb.WriteString(fmt.Sprintf("  Labels:      %s\n", strings.Join(task.Labels, ", ")))
-	}
 	sb.WriteString(fmt.Sprintf("  Priority:    %d\n", task.Priority))
 	sb.WriteString("\nAvailable agents:\n")
 	for _, a := range agents {
-		if a.State != types.AgentStateIdle {
+		if a.Status != types.AgentStatusIdle {
 			continue
 		}
 		sb.WriteString(fmt.Sprintf("  - %s (type: %s, capabilities: %s)\n",
-			a.Name, string(a.AgentType), strings.Join(a.Capabilities, ", ")))
+			a.Name, string(a.Type), strings.Join(a.Capabilities, ", ")))
 	}
 	sb.WriteString("\nRespond with ONLY the name of the most appropriate agent ")
 	sb.WriteString("(exactly as listed above), or 'any' if you have no preference. ")

--- a/internal/decision/llm_maker_test.go
+++ b/internal/decision/llm_maker_test.go
@@ -17,10 +17,10 @@ func makeAgents(names ...string) []*types.Agent {
 	agents := make([]*types.Agent, len(names))
 	for i, name := range names {
 		agents[i] = &types.Agent{
-			ID:           types.AgentID(name),
+			ID:           name,
 			Name:         name,
-			AgentType:    types.AgentTypeGeneral,
-			State:        types.AgentStateIdle,
+			Type:         types.AgentTypeGeneral,
+			Status:       types.AgentStatusIdle,
 			Capabilities: []string{"code", "planning"},
 		}
 	}
@@ -42,7 +42,7 @@ func TestLLMMaker_FallbackWhenUnconfigured(t *testing.T) {
 		t.Error("expected IsAvailable=false when no URL configured")
 	}
 	agents := makeAgents("alice", "bob")
-	chosen, err := m.Decide(context.Background(), makeTask("do something"), agents)
+	chosen, err := m.DecideAgent(context.Background(), makeTask("do something"), agents)
 	if err != nil {
 		t.Fatalf("expected no error on fallback, got %v", err)
 	}
@@ -75,7 +75,7 @@ func TestLLMMaker_UsesLLMResponse(t *testing.T) {
 		t.Fatal("expected IsAvailable=true with configured URL")
 	}
 
-	chosen, err := m.Decide(context.Background(), makeTask("review code for PR #42"), agents)
+	chosen, err := m.DecideAgent(context.Background(), makeTask("review code for PR #42"), agents)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestLLMMaker_FallbackOnBrainError(t *testing.T) {
 	defer srv.Close()
 
 	m := NewLLMMaker(srv.URL, "test-token")
-	chosen, err := m.Decide(context.Background(), makeTask("urgent task"), agents)
+	chosen, err := m.DecideAgent(context.Background(), makeTask("urgent task"), agents)
 	if err != nil {
 		t.Fatalf("expected no error even on brain 503, got %v", err)
 	}
@@ -119,7 +119,7 @@ func TestLLMMaker_FallbackOnUnknownAgentName(t *testing.T) {
 	defer srv.Close()
 
 	m := NewLLMMaker(srv.URL, "token")
-	chosen, err := m.Decide(context.Background(), makeTask("task"), agents)
+	chosen, err := m.DecideAgent(context.Background(), makeTask("task"), agents)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestLLMMaker_AnyResponse(t *testing.T) {
 	defer srv.Close()
 
 	m := NewLLMMaker(srv.URL, "token")
-	chosen, err := m.Decide(context.Background(), makeTask("task"), agents)
+	chosen, err := m.DecideAgent(context.Background(), makeTask("task"), agents)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestLLMMaker_TimeoutFallback(t *testing.T) {
 	m.httpClient = &http.Client{Timeout: 100 * time.Millisecond}
 
 	start := time.Now()
-	chosen, err := m.Decide(context.Background(), makeTask("urgent"), agents)
+	chosen, err := m.DecideAgent(context.Background(), makeTask("urgent"), agents)
 	elapsed := time.Since(start)
 
 	if err != nil {


### PR DESCRIPTION
## Summary

`make start` was failing at the Docker build stage because `internal/decision/llm_maker.go` (and its test) were written against a `pkg/types` schema that doesn't exist in this repo. Every reference was a one-to-one drift from the actual types — no schema change is needed, just align the new file with what's already there.

## Build error

```
internal/decision/llm_maker.go:43:7: undefined: Maker
internal/decision/llm_maker.go:76:21: m.fallback.Decide undefined (type *SimpleMaker has no field or method Decide)
internal/decision/llm_maker.go:103:14: task.Labels undefined (type *types.Task has no field or method Labels)
internal/decision/llm_maker.go:109:8:  a.State undefined (type *types.Agent has no field or method State)
internal/decision/llm_maker.go:109:23: undefined: types.AgentStateIdle
internal/decision/llm_maker.go:113:21: a.AgentType undefined (type *types.Agent has no field or method AgentType)
```
Reference: https://github.com/jordanhubbard/loom/issues/42

## Changes

**`internal/decision/llm_maker.go`**
- `Maker` → `types.DecisionMaker` (interface assertion + doc comments)
- Renamed `Decide` → `DecideAgent` (method + 3 fallback call sites) to satisfy `types.DecisionMaker`
- Added `EvaluatePriority` method that delegates to the `SimpleMaker` fallback — also required by `types.DecisionMaker`
- Dropped the `task.Labels` block (`Task` has no `Labels` field)
- `a.State` → `a.Status`, `types.AgentStateIdle` → `types.AgentStatusIdle`, `a.AgentType` → `a.Type`

**`internal/decision/llm_maker_test.go`**
- Same field renames (`AgentType:` → `Type:`, `State:` → `Status:`, `AgentStateIdle` → `AgentStatusIdle`)
- `types.AgentID(name)` → `name` (`Agent.ID` is a plain `string`)
- `m.Decide(...)` → `m.DecideAgent(...)` at all 6 call sites

No changes to `pkg/types` or `decision.go` — the rest of the codebase is already consistent with the existing schema, so the fix is scoped to the two drifted files.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/decision/...` — all `TestLLMMaker_*` tests pass
- [x] `make start` — Docker build of `loom-test` and `loom-agent-qa` gets past stage 10/12
